### PR TITLE
迭代前判断count

### DIFF
--- a/src/EventHorizon.BTree/BTree.cs
+++ b/src/EventHorizon.BTree/BTree.cs
@@ -149,9 +149,12 @@ public sealed class BTree<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue?
 
     public IEnumerator<KeyValuePair<TKey, TValue?>> GetEnumerator()
     {
-        foreach (var item in _root!.InOrderTraversal())
+        if (_count > 0)
         {
-            yield return new KeyValuePair<TKey, TValue?>(item.Key, item.Value);
+            foreach (var item in _root!.InOrderTraversal())
+            {
+                yield return new KeyValuePair<TKey, TValue?>(item.Key, item.Value);
+            }
         }
     }
 

--- a/src/EventHorizon.BTree/BTree.cs
+++ b/src/EventHorizon.BTree/BTree.cs
@@ -149,12 +149,14 @@ public sealed class BTree<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue?
 
     public IEnumerator<KeyValuePair<TKey, TValue?>> GetEnumerator()
     {
-        if (_count > 0)
+        if (_count == 0 || _root == null)
         {
-            foreach (var item in _root!.InOrderTraversal())
-            {
-                yield return new KeyValuePair<TKey, TValue?>(item.Key, item.Value);
-            }
+            yield break;
+        }
+
+        foreach (var item in _root.InOrderTraversal())
+        {
+            yield return new KeyValuePair<TKey, TValue?>(item.Key, item.Value);
         }
     }
 

--- a/tests/EventHorizon.BTree.Tests/BTree.Generic.Tests.cs
+++ b/tests/EventHorizon.BTree.Tests/BTree.Generic.Tests.cs
@@ -69,4 +69,23 @@ public abstract class BTree_Generic_Tests<TKey, TValue>
         // Assert
         Assert.Throws<ArgumentNullException>(() => GenericBTreeFactory(3, null!));
     }
+
+    [Fact]
+    public void BTree_Foreach_Test()
+    {
+        var btree = GenericBTreeFactory(10);
+        foreach (var _ in btree)
+        {
+             
+        }
+        Assert.Equal(0, btree.Count);
+        var key =CreateTKey(1);
+        var value = CreateTValue(2);
+        btree.Add(key,value );
+        foreach (var (key1, value1) in btree)
+        {
+            Assert.Equal(value, value1);
+        }
+        Assert.Equal(1, btree.Count);
+    }
 }

--- a/tests/EventHorizon.BTree.Tests/BTree.Generic.Tests.cs
+++ b/tests/EventHorizon.BTree.Tests/BTree.Generic.Tests.cs
@@ -79,6 +79,10 @@ public abstract class BTree_Generic_Tests<TKey, TValue>
              
         }
         Assert.Equal(0, btree.Count);
+
+        var enumerator = btree.GetEnumerator();
+        Assert.False(enumerator.MoveNext());
+
         var key =CreateTKey(1);
         var value = CreateTValue(2);
         btree.Add(key,value );
@@ -88,4 +92,5 @@ public abstract class BTree_Generic_Tests<TKey, TValue>
         }
         Assert.Equal(1, btree.Count);
     }
+    
 }


### PR DESCRIPTION
创建新的树，当前Node还未初始化，此次 _root 是null。如果不小心使用 foreach循环，会抛出null异常。认为应该需要判断一下count